### PR TITLE
openstack.yaml: bigger disk for buildpackages VM

### DIFF
--- a/teuthology/openstack/openstack.yaml
+++ b/teuthology/openstack/openstack.yaml
@@ -18,10 +18,10 @@ archive-on-error: true
 tasks:
    - buildpackages:
        good_machine:
-         disk: 40 # GB
+         disk: 100 # GB
          ram: 15000 # MB
          cpus: 16
        min_machine:
-         disk: 40 # GB
+         disk: 100 # GB
          ram: 8000 # MB
          cpus: 1


### PR DESCRIPTION
Addresses following error in make-deb.sh:

"Error 28 while writing to
trusty/ceph-deb-trusty-x86_64-basic/sha1/3168a8482211a2aaf9b4d715c0f7a920e896d9bb/pool/main/c/ceph/ceph-common-dbg_10.2.2-503-g3168a84-1_amd64.deb:
No space left on device"

Signed-off-by: Nathan Cutler <ncutler@suse.com>